### PR TITLE
Schedule at specific time and faster testing

### DIFF
--- a/Sources/Jobs/Job.swift
+++ b/Sources/Jobs/Job.swift
@@ -89,7 +89,7 @@ public protocol ScheduledJob {
     func run(context: JobContext) -> EventLoopFuture<Void>
 }
 
-struct AnyScheduledJob {
+class AnyScheduledJob {
     let job: ScheduledJob
     let scheduler: ScheduleBuilder?
     let date: Date?

--- a/Sources/Jobs/Job.swift
+++ b/Sources/Jobs/Job.swift
@@ -91,18 +91,10 @@ public protocol ScheduledJob {
 
 class AnyScheduledJob {
     let job: ScheduledJob
-    let scheduler: ScheduleBuilder?
-    let date: Date?
+    let scheduler: ScheduleBuilder
     
     init(job: ScheduledJob, scheduler: ScheduleBuilder) {
         self.job = job
         self.scheduler = scheduler
-        self.date = nil
-    }
-    
-    init(job: ScheduledJob, at date: Date) {
-        self.job = job
-        self.scheduler = nil
-        self.date = date
     }
 }

--- a/Sources/Jobs/Job.swift
+++ b/Sources/Jobs/Job.swift
@@ -91,5 +91,18 @@ public protocol ScheduledJob {
 
 struct AnyScheduledJob {
     let job: ScheduledJob
-    let scheduler: ScheduleBuilder
+    let scheduler: ScheduleBuilder?
+    let date: Date?
+    
+    init(job: ScheduledJob, scheduler: ScheduleBuilder) {
+        self.job = job
+        self.scheduler = scheduler
+        self.date = nil
+    }
+    
+    init(job: ScheduledJob, at date: Date) {
+        self.job = job
+        self.scheduler = nil
+        self.date = date
+    }
 }

--- a/Sources/Jobs/JobsConfiguration.swift
+++ b/Sources/Jobs/JobsConfiguration.swift
@@ -63,10 +63,6 @@ public struct JobsConfiguration {
         return builder
     }
     
-    mutating internal func schedule<J>(_ job: J, at date: Date) where J: ScheduledJob {
-        self.scheduledStorage.append(AnyScheduledJob(job: job, at: date))
-    }
-    
     /// Returns the `AnyJob` for the string it was registered under
     ///
     /// - Parameter key: The key of the job

--- a/Sources/Jobs/JobsConfiguration.swift
+++ b/Sources/Jobs/JobsConfiguration.swift
@@ -55,13 +55,16 @@ public struct JobsConfiguration {
     ///     .at(.noon)
     ///
     /// - Parameter job: The `ScheduledJob` to be scheduled.
-    mutating public func schedule<J>(_ job: J, builder: ScheduleBuilder? = nil) -> ScheduleBuilder
+    mutating internal func schedule<J>(_ job: J, builder: ScheduleBuilder = ScheduleBuilder()) -> ScheduleBuilder
         where J: ScheduledJob
     {
-        let scheduler = builder ?? ScheduleBuilder()
-        let storage = AnyScheduledJob(job: job, scheduler: scheduler)
+        let storage = AnyScheduledJob(job: job, scheduler: builder)
         self.scheduledStorage.append(storage)
-        return scheduler
+        return builder
+    }
+    
+    mutating internal func schedule<J>(_ job: J, at date: Date) where J: ScheduledJob {
+        self.scheduledStorage.append(AnyScheduledJob(job: job, at: date))
     }
     
     /// Returns the `AnyJob` for the string it was registered under

--- a/Sources/Jobs/JobsProvider.swift
+++ b/Sources/Jobs/JobsProvider.swift
@@ -65,6 +65,12 @@ public struct ApplicationJobs {
         }
         return builder
     }
+    
+    public func schedule<J>(_ job: J, at date: Date) where J: ScheduledJob {
+        application.register(extension: JobsConfiguration.self) { jobs, app in
+            jobs.schedule(job, at: date)
+        }
+    }
 }
 
 extension Application {

--- a/Sources/Jobs/JobsProvider.swift
+++ b/Sources/Jobs/JobsProvider.swift
@@ -65,12 +65,6 @@ public struct ApplicationJobs {
         }
         return builder
     }
-    
-    public func schedule<J>(_ job: J, at date: Date) where J: ScheduledJob {
-        application.register(extension: JobsConfiguration.self) { jobs, app in
-            jobs.schedule(job, at: date)
-        }
-    }
 }
 
 extension Application {

--- a/Sources/Jobs/ScheduledJobsWorker.swift
+++ b/Sources/Jobs/ScheduledJobsWorker.swift
@@ -81,8 +81,16 @@ final class ScheduledJobsWorker {
                         self.scheduledJobs.append((job, nextDate))
                         self.run(job: job, date: nextDate)
                     }
+                } else {
+                    guard let index = self.scheduledJobs.firstIndex(where: { $0.0 === job }) else { return }
+                    self.scheduledJobs.remove(at: index)
+                    if self.scheduledJobs.first(where: { $0.0.scheduler != nil }) == nil {
+                        // We do not have any scheduled jobs, check for one-off jobs
+                        if self.scheduledJobs.filter({ $0.0.date != nil }).count == 0 {
+                            self.shutdownPromise.succeed(())
+                        }
+                    }
                 }
-                
             }.transform(to: ())
         }
     }

--- a/Sources/Jobs/Scheduler/ScheduleBuilder.swift
+++ b/Sources/Jobs/Scheduler/ScheduleBuilder.swift
@@ -339,6 +339,10 @@ public final class ScheduleBuilder {
 
     /// returns the next date that satisfies the schedule
     internal func resolveNextDateThatSatisifiesSchedule(date: Date) throws -> Date {
+        if let oneTimeDate = self.date {
+            return oneTimeDate
+        }
+        
         var monthConstraint: MonthRecurrenceRuleConstraint?
         if let monthValue = month?.rawValue {
             monthConstraint = try MonthRecurrenceRuleConstraint.atMonth(monthValue)
@@ -388,7 +392,10 @@ public final class ScheduleBuilder {
     }
 
     // MARK: Properties
-
+    
+    /// Date to perform task (one-off job)
+    var date: Date?
+    
     var month: Month?
     var day: Day?
     var dayOfWeek: DayOfWeek?
@@ -399,7 +406,12 @@ public final class ScheduleBuilder {
     init() { }
 
     // MARK: Helpers
-
+    
+    /// Schedules a job at a specific date
+    public func at(_ date: Date) -> Void {
+        self.date = date
+    }
+    
     /// Creates a yearly scheduled job for further building
     public func yearly() -> Yearly {
         return Yearly(builder: self)

--- a/Sources/Jobs/Scheduler/ScheduleBuilder.swift
+++ b/Sources/Jobs/Scheduler/ScheduleBuilder.swift
@@ -224,6 +224,32 @@ public final class ScheduleBuilder {
             self.init(value)
         }
     }
+    
+    /// Describes a second numeral
+    public struct Second: ExpressibleByIntegerLiteral, CustomStringConvertible {
+        let number: Int
+
+        /// The readable second, zero padded.
+        public var description: String {
+            switch self.number {
+            case 0..<10:
+                return "0" + self.number.description
+            default:
+                return self.number.description
+            }
+        }
+
+        init(_ number: Int) {
+            assert(number >= 0, "Second cannot preceed 0")
+            assert(number < 60, "Second cannot exceed 60")
+            self.number = number
+        }
+
+        /// Takes an integerLiteral and creates a `Second`. Must be `>= 0 && < 60`
+        public init(integerLiteral value: Int) {
+            self.init(value)
+        }
+    }
 
     // MARK: Builders
 
@@ -299,6 +325,17 @@ public final class ScheduleBuilder {
             self.builder.minute = minute
         }
     }
+    
+    /// An object to build a `EveryMinute` scheduled job
+    public struct EveryMinute {
+        let builder: ScheduleBuilder
+        
+        /// The second to run the job at
+        /// - Parameter second: A `Second` to run the job at
+        public func at(_ second: Second) {
+            self.builder.second = second
+        }
+    }
 
     /// returns the next date that satisfies the schedule
     internal func resolveNextDateThatSatisifiesSchedule(date: Date) throws -> Date {
@@ -337,8 +374,8 @@ public final class ScheduleBuilder {
         if let minuteValue = minute?.number {
             minuteConstraint = try MinuteRecurrenceRuleConstraint.atMinute(minuteValue)
         }
-
-        let secondConstraint = try SecondRecurrenceRuleConstraint.atSecond(0)
+        
+        let secondConstraint = try SecondRecurrenceRuleConstraint.atSecond(second.number)
         let recurrenceRule = try RecurrenceRule(yearConstraint: nil,
                                                 monthConstraint: monthConstraint,
                                                 dayOfMonthConstraint: dayOfMonthConstraint,
@@ -357,6 +394,7 @@ public final class ScheduleBuilder {
     var dayOfWeek: DayOfWeek?
     var time: Time?
     var minute: Minute?
+    var second: Second = Second(0)
 
     init() { }
 
@@ -385,5 +423,9 @@ public final class ScheduleBuilder {
     /// Creates a hourly scheduled job for further building
     public func hourly() -> Hourly {
         return Hourly(builder: self)
+    }
+    
+    public func everyMinute() -> EveryMinute {
+        return EveryMinute(builder: self)
     }
 }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -26,7 +26,8 @@ final class JobsTests: XCTestCase {
         let app = try self.startServer()
         defer { app.shutdown() }
         app.jobs.schedule(Cleanup()).hourly().at(30)
-        app.jobs.schedule(Cleanup(), at: Date() + 5)
+        app.jobs.schedule(Cleanup()).at(Date() + 5)
+    
         XCTAssertEqual(app.make(JobsConfiguration.self).scheduledStorage.count, 2)
     }
     

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -26,7 +26,8 @@ final class JobsTests: XCTestCase {
         let app = try self.startServer()
         defer { app.shutdown() }
         app.jobs.schedule(Cleanup()).hourly().at(30)
-        XCTAssertEqual(app.make(JobsConfiguration.self).scheduledStorage.count, 1)
+        app.jobs.schedule(Cleanup(), at: Date() + 5)
+        XCTAssertEqual(app.make(JobsConfiguration.self).scheduledStorage.count, 2)
     }
     
     private func startServer() throws -> Application {

--- a/Tests/JobsTests/JobsWorkerTests.swift
+++ b/Tests/JobsTests/JobsWorkerTests.swift
@@ -46,7 +46,7 @@ final class JobsWorkerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Waits for scheduled job to be completed")
         var config = JobsConfiguration()
         
-        config.schedule(DailyCleanupScheduledJob(expectation: expectation), at: Date().addingTimeInterval(5))
+        config.schedule(DailyCleanupScheduledJob(expectation: expectation)).at(Date().addingTimeInterval(5))
         
         let logger = Logger(label: "com.vapor.codes.jobs.tests")
         let worker = ScheduledJobsWorker(

--- a/Tests/JobsTests/JobsWorkerTests.swift
+++ b/Tests/JobsTests/JobsWorkerTests.swift
@@ -61,7 +61,7 @@ final class JobsWorkerTests: XCTestCase {
         
         try elg.next().scheduleTask(in: .seconds(1)) { () -> Void in
             // Test that job was not rescheduled
-            XCTAssertEqual(worker.scheduledJobs.count, 1)
+            XCTAssertEqual(worker.scheduledJobs.count, 0)
             worker.shutdown()
         }.futureResult.wait()
     }

--- a/Tests/JobsTests/Scheduler/SchedulerTests.swift
+++ b/Tests/JobsTests/Scheduler/SchedulerTests.swift
@@ -66,7 +66,7 @@ final class SchedulerTests: XCTestCase {
         // May 31, 2019 12:00:00
         let date2 = dateFormatter.date(from: "2019-05-23T12:00:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -87,7 +87,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 15, 2019 24:00:00
         let date2 = dateFormatter.date(from: "2019-01-15T00:00:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -108,7 +108,7 @@ final class SchedulerTests: XCTestCase {
         // Mon Jan 7, 2019 3:13:00
         let date2 = dateFormatter.date(from: "2019-01-07T3:13:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -128,7 +128,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date2 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
 
         // daily 2
@@ -142,7 +142,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date4 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate2 = try config.scheduledStorage[1].scheduler!.resolveNextDateThatSatisifiesSchedule(date: date3)
+        let nextDate2 = try config.scheduledStorage[1].scheduler.resolveNextDateThatSatisifiesSchedule(date: date3)
         XCTAssertEqual(nextDate2, date4)
 
         // daily 3
@@ -156,7 +156,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date6 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate3 = try config.scheduledStorage[2].scheduler!.resolveNextDateThatSatisifiesSchedule(date: date5)
+        let nextDate3 = try config.scheduledStorage[2].scheduler.resolveNextDateThatSatisifiesSchedule(date: date5)
         XCTAssertEqual(nextDate3, date6)
     }
 
@@ -176,7 +176,27 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 0:30:00
         let date2 = dateFormatter.date(from: "2019-01-01T0:30:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        XCTAssertEqual(nextDate, date2)
+    }
+    
+    func testScheduleEvaluationEveryMinute() throws {
+        var config = JobsConfiguration()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        
+        // hourly
+        config.schedule(Cleanup())
+            .everyMinute()
+            .at(30)
+        
+        // Fri, Jan 1, 2019 00:00:00
+        let date1 = dateFormatter.date(from: "2019-01-01T00:00:00")!
+        
+        // Jan 1, 2019 0:00:30
+        let date2 = dateFormatter.date(from: "2019-01-01T0:00:30")!
+        
+        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 }

--- a/Tests/JobsTests/Scheduler/SchedulerTests.swift
+++ b/Tests/JobsTests/Scheduler/SchedulerTests.swift
@@ -66,7 +66,7 @@ final class SchedulerTests: XCTestCase {
         // May 31, 2019 12:00:00
         let date2 = dateFormatter.date(from: "2019-05-23T12:00:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -87,7 +87,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 15, 2019 24:00:00
         let date2 = dateFormatter.date(from: "2019-01-15T00:00:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -108,7 +108,7 @@ final class SchedulerTests: XCTestCase {
         // Mon Jan 7, 2019 3:13:00
         let date2 = dateFormatter.date(from: "2019-01-07T3:13:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 
@@ -128,7 +128,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date2 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
 
         // daily 2
@@ -142,7 +142,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date4 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate2 = try config.scheduledStorage[1].scheduler.resolveNextDateThatSatisifiesSchedule(date: date3)
+        let nextDate2 = try config.scheduledStorage[1].scheduler!.resolveNextDateThatSatisifiesSchedule(date: date3)
         XCTAssertEqual(nextDate2, date4)
 
         // daily 3
@@ -156,7 +156,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 17:23:00
         let date6 = dateFormatter.date(from: "2019-01-01T17:23:00")!
 
-        let nextDate3 = try config.scheduledStorage[2].scheduler.resolveNextDateThatSatisifiesSchedule(date: date5)
+        let nextDate3 = try config.scheduledStorage[2].scheduler!.resolveNextDateThatSatisifiesSchedule(date: date5)
         XCTAssertEqual(nextDate3, date6)
     }
 
@@ -176,7 +176,7 @@ final class SchedulerTests: XCTestCase {
         // Jan 1, 2019 0:30:00
         let date2 = dateFormatter.date(from: "2019-01-01T0:30:00")!
 
-        let nextDate = try config.scheduledStorage.first?.scheduler.resolveNextDateThatSatisifiesSchedule(date: date1)
+        let nextDate = try config.scheduledStorage.first?.scheduler!.resolveNextDateThatSatisifiesSchedule(date: date1)
         XCTAssertEqual(nextDate, date2)
     }
 }

--- a/Tests/JobsTests/XCTestManifests.swift
+++ b/Tests/JobsTests/XCTestManifests.swift
@@ -54,6 +54,7 @@ extension JobsWorkerTests {
     // to regenerate.
     static let __allTests__JobsWorkerTests = [
         ("testScheduledJob", testScheduledJob),
+        ("testScheduledJobAt", testScheduledJobAt),
     ]
 }
 

--- a/Tests/JobsTests/XCTestManifests.swift
+++ b/Tests/JobsTests/XCTestManifests.swift
@@ -105,6 +105,7 @@ extension SchedulerTests {
     static let __allTests__SchedulerTests = [
         ("testConfiguration", testConfiguration),
         ("testScheduleEvaluationDaily", testScheduleEvaluationDaily),
+        ("testScheduleEvaluationEveryMinute", testScheduleEvaluationEveryMinute),
         ("testScheduleEvaluationHourly", testScheduleEvaluationHourly),
         ("testScheduleEvaluationMonthly", testScheduleEvaluationMonthly),
         ("testScheduleEvaluationWeekly", testScheduleEvaluationWeekly),


### PR DESCRIPTION
This fixes #37 

I've added `Seconds` in order to do a shorter interval, as well as a `schedule(at:)` function.

I've discussed with @mcdappdev regarding threading semantics and the thing I am unsure of is the shutdown functionality. If it's alright in terms of threading and etc. So any help or contributions there would be great.