### PR TITLE
Fail early if no scheduled jobs exist

### DIFF
--- a/Sources/Jobs/JobsCommand.swift
+++ b/Sources/Jobs/JobsCommand.swift
@@ -108,7 +108,11 @@ public final class JobsCommand: Command {
     
     /// Starts the scheduled jobs in-process
     public func startScheduledJobs() throws {
-        precondition(!self.application.jobs.configuration.scheduledJobs.isEmpty, "Must schedule at least one job before calling startScheduledJobs")
+        guard !self.application.jobs.configuration.scheduledJobs.isEmpty else {
+            self.application.logger.warning("No scheduled jobs exist, exiting scheduled jobs worker.")
+            return
+        }
+        
         self.application.jobs.configuration.scheduledJobs
             .forEach { self.schedule($0) }
     }

--- a/Sources/Jobs/JobsCommand.swift
+++ b/Sources/Jobs/JobsCommand.swift
@@ -108,6 +108,7 @@ public final class JobsCommand: Command {
     
     /// Starts the scheduled jobs in-process
     public func startScheduledJobs() throws {
+        precondition(!self.application.jobs.configuration.scheduledJobs.isEmpty, "Must schedule at least one job before calling startScheduledJobs")
         self.application.jobs.configuration.scheduledJobs
             .forEach { self.schedule($0) }
     }


### PR DESCRIPTION
If no scheduled jobs exist, fail early from the process to avoid running the worker unnecessarily. 