### PR TITLE
Fix everySecond bug

### DIFF
--- a/Sources/Jobs/ScheduleBuilder.swift
+++ b/Sources/Jobs/ScheduleBuilder.swift
@@ -342,6 +342,9 @@ public final class ScheduleBuilder {
         }
         
         var components = DateComponents()
+        if let milliseconds = millisecond {
+            components.nanosecond = milliseconds
+        }
         if let second = self.second {
             components.second = second.number
         }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -85,10 +85,11 @@ final class JobsTests: XCTestCase {
         
         XCTAssertEqual(TestingScheduledJob.count, 0)
         app.jobs.schedule(TestingScheduledJob()).everySecond()
+        try JobsCommand(application: app, scheduled: true).startScheduledJobs()
         
         let promise = app.eventLoopGroup.next().makePromise(of: Void.self)
         app.eventLoopGroup.next().scheduleTask(in: .seconds(5)) { () -> Void in
-            XCTAssert(TestingScheduledJob.count > 1)
+            XCTAssert(TestingScheduledJob.count > 4)
             promise.succeed(())
         }
         


### PR DESCRIPTION
This update fixes a bug that caused `everySecond()` not to fire when running scheduled jobs. 