### PR TITLE
Use Same EventLoop in Job Worker

### DIFF
--- a/Sources/Jobs/JobsCommand.swift
+++ b/Sources/Jobs/JobsCommand.swift
@@ -87,7 +87,7 @@ public final class JobsCommand: Command {
     /// - Parameter queueName: The queue to run the jobs on
     public func startJobs(on queueName: JobsQueueName) throws {
         for eventLoop in eventLoopGroup.makeIterator() {
-            let worker = self.application.jobs.queue(queueName).worker
+            let worker = self.application.jobs.queue(queueName, on: eventLoop).worker
             let task = eventLoop.scheduleRepeatedAsyncTask(
                 initialDelay: .seconds(0),
                 delay: worker.queue.configuration.refreshInterval


### PR DESCRIPTION
Job workers will now use the same EventLoop as the scheduled task that runs them (fixes https://github.com/vapor/jobs-redis-driver/issues/11, #59).