### PR TITLE
Add @discardableResult to Queue's dispatch function

### DIFF
--- a/Sources/Queues/Queue.swift
+++ b/Sources/Queues/Queue.swift
@@ -57,6 +57,7 @@ extension Queue {
     ///   - payload: The payload data to be dispatched
     ///   - maxRetryCount: Number of times to retry this job on failure
     ///   - delayUntil: Delay the processing of this job until a certain date
+    @discardableResult
     public func dispatch<J>(
         _ job: J.Type,
         _ payload: J.Payload,


### PR DESCRIPTION
When using a queue to dispatch a function, the caller might not want to get the `EventLoopFuture<Void>` that is returned.