### PR TITLE
Make AsyncScheduledJob public so clients can conform to it

### DIFF
--- a/Sources/Queues/AsyncScheduledJob.swift
+++ b/Sources/Queues/AsyncScheduledJob.swift
@@ -5,7 +5,7 @@ import Foundation
 #if compiler(>=5.5) && canImport(_Concurrency)
 /// Describes a job that can be scheduled and repeated
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
-protocol AsyncScheduledJob: ScheduledJob {
+public protocol AsyncScheduledJob: ScheduledJob {
     var name: String { get }
     
     /// The method called when the job is run
@@ -17,7 +17,7 @@ protocol AsyncScheduledJob: ScheduledJob {
 extension AsyncScheduledJob {
     public var name: String { "\(Self.self)" }
     
-    func run(context: QueueContext) -> EventLoopFuture<Void> {
+    public func run(context: QueueContext) -> EventLoopFuture<Void> {
         let promise = context.eventLoop.makePromise(of: Void.self)
         promise.completeWithTask {
             try await self.run(context: context)


### PR DESCRIPTION
This PR allows client apps to conform to the previously-added `AsyncScheduledJob` protocol by making it, and the associated adapter function from `ScheduledJob`, public.