### PR TITLE
Fix scheduled job double-fire caused by NIO timer jitter

### DIFF
--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -460,7 +460,7 @@ final class QueueTests: XCTestCase {
         XCTAssert(self.app.queues.test.contains(Baz.self))
         XCTAssertNotNil(job)
 
-        try await Task.sleep(1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
 
         try await self.app.queues.queue.worker.run()
         XCTAssertFalse(successHook.successHit)
@@ -503,7 +503,7 @@ final class QueueTests: XCTestCase {
         XCTAssert(self.app.queues.test.contains(Baz.self))
         XCTAssertNotNil(job)
 
-        try await Task.sleep(1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
 
         try await self.app.queues.queue.worker.run()
         await XCTAssertFalseAsync(await successHook.successHit)

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -460,7 +460,7 @@ final class QueueTests: XCTestCase {
         XCTAssert(self.app.queues.test.contains(Baz.self))
         XCTAssertNotNil(job)
 
-        sleep(1)
+        try await Task.sleep(1_000_000_000)
 
         try await self.app.queues.queue.worker.run()
         XCTAssertFalse(successHook.successHit)
@@ -503,7 +503,7 @@ final class QueueTests: XCTestCase {
         XCTAssert(self.app.queues.test.contains(Baz.self))
         XCTAssertNotNil(job)
 
-        sleep(1)
+        try await Task.sleep(1_000_000_000)
 
         try await self.app.queues.queue.worker.run()
         await XCTAssertFalseAsync(await successHook.successHit)


### PR DESCRIPTION
**These changes are now available in [1.17.3](https://github.com/vapor/queues/releases/tag/1.17.3)**


<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
On some platforms (n my case, Fly.io's Firecracker microVMs), NIO's monotonic clock can fire a large-delay timer slightly early. For example, when a daily job is scheduled for 20:00:00 and the timer fires at 19:59:59.8, the job runs as expected. However, the subsequent call to self.schedule(job) then called scheduler.nextDate() with no argument, defaulting current to Date() which is still 19:59:59.8-ish. Because 20:00:00 is still in the future from that reference point, nextDate returns 20:00:00 again, causing the job to fire a second time ~200ms later. The fix passes the originally-scheduled date to the next schedule call so that nextDate(current:) always advances to the following occurrence rather than potentially returning the current one. Two small changes:

AnyScheduledJob.Task gains a scheduledDate: Date field so the scheduled date can be threaded through the completion handler. AnyScheduledJob.schedule(context:after:) accepts an optional previousDate and uses it (falling back to Date() on the first call) as the current argument to ScheduleBuilder.nextDate. QueuesCommand.schedule(_:after:) captures task.scheduledDate and passes it on the recursive call.

Fixes: https://github.com/vapor/queues/issues/85
Fixes: https://github.com/vapor/queues/issues/94
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
