### PR TITLE
Add every(interval) feature

### DIFF
--- a/Sources/Queues/ScheduleBuilder.swift
+++ b/Sources/Queues/ScheduleBuilder.swift
@@ -182,6 +182,7 @@ public final class ScheduleBuilder: @unchecked Sendable {
     
     /// Retrieves the next date after the one given.
     public func nextDate(current: Date = .init()) -> Date? {
+        if let interval = self.interval { return current.addingTimeInterval(interval) }
         if let date = self.date, date > current { return date }
 
         var components = DateComponents()
@@ -202,11 +203,12 @@ public final class ScheduleBuilder: @unchecked Sendable {
     
     /// The calendar used to compute the next date
     var calendar: Calendar
-    
+
     /// Date to perform task (one-off job)
     var date: Date?
     var month: Month?, day: Day?, weekday: Weekday?
     var time: Time?, minute: Minute?, second: Second?, millisecond: Int?
+    var interval: TimeInterval?
 
     public init(calendar: Calendar = .current) { self.calendar = calendar }
 
@@ -236,4 +238,19 @@ public final class ScheduleBuilder: @unchecked Sendable {
 
     /// Runs a job every second
     public func everySecond() { self.millisecond = 0 }
+
+    /// Runs a job every given number of seconds
+    public func every(seconds: Int) { self.interval = TimeInterval(seconds) }
+
+    /// Runs a job every given number of minutes
+    public func every(minutes: Int) { self.interval = TimeInterval(minutes * 60) }
+
+    /// Runs a job every given number of hours
+    public func every(hours: Int) { self.interval = TimeInterval(hours * 3_600) }
+
+    /// Runs a job every given number of days
+    public func every(days: Int) { self.interval = TimeInterval(days * 86_400) }
+
+    /// Runs a job every given number of weeks
+    public func every(weeks: Int) { self.interval = TimeInterval(weeks * 604_800) }
 }

--- a/Sources/XCTQueues/TestQueueDriver.swift
+++ b/Sources/XCTQueues/TestQueueDriver.swift
@@ -107,13 +107,18 @@ extension Application.Queues {
     }
 }
 
+struct NoSuchJobError: Error { let id: JobIdentifier }
+
 struct TestQueue: Queue {
     let _context: NIOLockedValueBox<QueueContext>
     var context: QueueContext { self._context.withLockedValue { $0 } }
 
     func get(_ id: JobIdentifier) -> EventLoopFuture<JobData> {
         self._context.withLockedValue { context in
-            context.eventLoop.makeSucceededFuture(context.application.queues.test.jobs[id]!)
+            guard let job = context.application.queues.test.jobs[id] else {
+                return context.eventLoop.makeFailedFuture(NoSuchJobError(id: id))
+            }
+            return context.eventLoop.makeSucceededFuture(job)
         }
     }
 
@@ -150,7 +155,7 @@ struct AsyncTestQueue: AsyncQueue {
     let _context: NIOLockedValueBox<QueueContext>
     var context: QueueContext { self._context.withLockedValue { $0 } }
 
-    func get(_ id: JobIdentifier) async throws -> JobData { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id]! } }
+    func get(_ id: JobIdentifier) async throws -> JobData { try self._context.withLockedValue { guard let job = $0.application.queues.asyncTest.jobs[id] else { throw NoSuchJobError(id: id) }; return job } }
     func set(_ id: JobIdentifier, to data: JobData) async throws { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id] = data } }
     func clear(_ id: JobIdentifier) async throws { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id] = nil } }
     func pop() async throws -> JobIdentifier? { self._context.withLockedValue { $0.application.queues.asyncTest.queue.popLast() } }

--- a/Tests/QueuesTests/ScheduleBuilderTests.swift
+++ b/Tests/QueuesTests/ScheduleBuilderTests.swift
@@ -138,7 +138,44 @@ final class ScheduleBuilderTests: XCTestCase {
             Date(year: 2020, month: 5, day: 23, hour: 14, minute: 58)
         )
     }
-    
+
+    func testEveryWeeksBuilder() throws {
+        let builder = ScheduleBuilder()
+        builder.every(weeks: 3)
+        let now = Date(hour: 5, minute: 0)
+        XCTAssertEqual(builder.nextDate(current: now), Date(day: 22, hour: 5))
+    }
+
+    func testEveryDaysBuilder() throws {
+        let builder = ScheduleBuilder()
+        builder.every(days: 9)
+        let now = Date(hour: 5, minute: 0)
+        XCTAssertEqual(builder.nextDate(current: now), Date(day: 10, hour: 5))
+    }
+
+    func testEveryMinutesBuilder() throws {
+        let builder = ScheduleBuilder()
+        builder.every(minutes: 30)
+        let now = Date(hour: 5, minute: 0)
+        XCTAssertEqual(builder.nextDate(current: now), Date(hour: 5, minute: 30))
+        XCTAssertEqual(builder.nextDate(current: Date(hour: 5, minute: 30)), Date(hour: 6, minute: 0))
+    }
+
+    func testEveryHoursBuilder() throws {
+        let builder = ScheduleBuilder()
+        builder.every(hours: 5)
+        let now = Date(hour: 0, minute: 0)
+        XCTAssertEqual(builder.nextDate(current: now), Date(hour: 5, minute: 0))
+        XCTAssertEqual(builder.nextDate(current: Date(hour: 5, minute: 0)), Date(hour: 10, minute: 0))
+    }
+
+    func testEverySecondsBuilder() throws {
+        let builder = ScheduleBuilder()
+        builder.every(seconds: 90)
+        let now = Date(hour: 1, minute: 0, second: 0)
+        XCTAssertEqual(builder.nextDate(current: now), Date(hour: 1, minute: 1, second: 30))
+    }
+
     func testCustomCalendarBuilder() throws {
         let est = Calendar.calendar(timezone: "EST")
         let mst = Calendar.calendar(timezone: "MST")


### PR DESCRIPTION
**These changes are now available in [1.18.0](https://github.com/vapor/queues/releases/tag/1.18.0)**


Adds a new feature to enable jobs to be scheduled using intervals of seconds, minutes, hours, days or weeks.

Examples:

```
.every(seconds: 3)
.every(minutes: 17)
.every(hours: 5)
.every(days: 4)
.every(weeks: 6)
```