### PR TITLE
Implement sequential execution of jobs with a single worker

### DIFF
--- a/Sources/Queues/QueueName.swift
+++ b/Sources/Queues/QueueName.swift
@@ -6,11 +6,20 @@ public struct QueueName: Sendable {
     /// The name of the queue
     public let string: String
 
+    /// The maximum number of workers to run for this queue, or `nil` to use the global ``QueuesConfiguration/workerCount``.
+    ///
+    /// Set this to `1` to ensure jobs on this queue execute one at a time.
+    public let workerCount: Int?
+
     /// Creates a new ``QueueName``
     ///
-    /// - Parameter name: The name of the queue
-    public init(string: String) {
+    /// - Parameters:
+    ///   - string: The name of the queue.
+    ///   - workerCount: The maximum number of workers to run for this queue.
+    ///     Defaults to `nil`, which defers to the global ``QueuesConfiguration/workerCount``.
+    public init(string: String, workerCount: Int? = nil) {
         self.string = string
+        self.workerCount = workerCount
     }
 
     /// Makes the name of the queue

--- a/Sources/Queues/QueueName.swift
+++ b/Sources/Queues/QueueName.swift
@@ -11,11 +11,16 @@ public struct QueueName: Sendable {
 
     /// Creates a new ``QueueName``
     ///
+    /// - Parameter string: The name of the queue
+    public init(string: String) {
+        self.init(string: string, workerCount: nil)
+    }
+
     /// - Parameters:
-    ///   - string: The name of the queue.
-    ///   - workerCount: The maximum number of workers to run for this queue.
-    ///     Defaults to `nil`, which defers to the global ``QueuesConfiguration/workerCount``.
-    public init(string: String, workerCount: Int? = nil) {
+    ///   - string: The name of the queue
+    ///   - workerCount: The maximum number of workers to run for this queue. If `nil`, defaults to ``QueuesConfiguration/workerCount``.
+    ///      Set to `1` to run jobs sequentially.
+    public init(string: String, workerCount: Int?) {
         self.string = string
         self.workerCount = workerCount
     }

--- a/Sources/Queues/QueueName.swift
+++ b/Sources/Queues/QueueName.swift
@@ -6,9 +6,7 @@ public struct QueueName: Sendable {
     /// The name of the queue
     public let string: String
 
-    /// The maximum number of workers to run for this queue, or `nil` to use the global ``QueuesConfiguration/workerCount``.
-    ///
-    /// Set this to `1` to ensure jobs on this queue execute one at a time.
+    /// The maximum number of workers to run for this queue. If `nil`, uses ``QueuesConfiguration/workerCount``.
     public let workerCount: Int?
 
     /// Creates a new ``QueueName``

--- a/Sources/Queues/QueuesCommand.swift
+++ b/Sources/Queues/QueuesCommand.swift
@@ -85,15 +85,16 @@ public final class QueuesCommand: AsyncCommand, Sendable {
     ///
     /// - Parameter queueName: The queue to run the jobs on
     public func startJobs(on queueName: QueueName) throws {
-        let workerCount: Int
+        let globalWorkerCount: Int
         switch self.application.queues.configuration.workerCount {
         case .default:
-            workerCount = self.application.eventLoopGroup.makeIterator().reduce(0, { n, _ in n + 1 })
-            self.application.logger.trace("Using default worker count", metadata: ["workerCount": "\(workerCount)"])
+            globalWorkerCount = self.application.eventLoopGroup.makeIterator().reduce(0, { n, _ in n + 1 })
+            self.application.logger.trace("Using default worker count", metadata: ["workerCount": "\(globalWorkerCount)"])
         case .custom(let custom):
-            workerCount = custom
-            self.application.logger.trace("Using custom worker count", metadata: ["workerCount": "\(workerCount)"])
+            globalWorkerCount = custom
+            self.application.logger.trace("Using custom worker count", metadata: ["workerCount": "\(globalWorkerCount)"])
         }
+        let workerCount = queueName.workerCount.map { min($0, globalWorkerCount) } ?? globalWorkerCount
 
         var tasks: [RepeatedTask] = []
         for eventLoop in self.application.eventLoopGroup.makeIterator().prefix(workerCount) {

--- a/Sources/XCTQueues/TestQueueDriver.swift
+++ b/Sources/XCTQueues/TestQueueDriver.swift
@@ -80,6 +80,13 @@ extension Application.Queues {
         public func contains<J: Job>(_ job: J.Type) -> Bool {
             self.first(job) != nil
         }
+
+        func popFirst() -> JobIdentifier? {
+            self.box.withLockedValue { box in
+                guard !box.queue.isEmpty else { return nil }
+                return box.queue.removeFirst()
+            }
+        }
     }
 
     struct TestQueueKey: StorageKey, LockKey {
@@ -133,8 +140,7 @@ struct TestQueue: Queue {
 
     func pop() -> EventLoopFuture<JobIdentifier?> {
         self._context.withLockedValue { context in
-            let last = context.application.queues.test.queue.popLast()
-            return context.eventLoop.makeSucceededFuture(last)
+            context.eventLoop.makeSucceededFuture(context.application.queues.test.popFirst())
         }
     }
 
@@ -153,6 +159,6 @@ struct AsyncTestQueue: AsyncQueue {
     func get(_ id: JobIdentifier) async throws -> JobData { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id]! } }
     func set(_ id: JobIdentifier, to data: JobData) async throws { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id] = data } }
     func clear(_ id: JobIdentifier) async throws { self._context.withLockedValue { $0.application.queues.asyncTest.jobs[id] = nil } }
-    func pop() async throws -> JobIdentifier? { self._context.withLockedValue { $0.application.queues.asyncTest.queue.popLast() } }
+    func pop() async throws -> JobIdentifier? { self._context.withLockedValue { $0.application.queues.asyncTest.popFirst() } }
     func push(_ id: JobIdentifier) async throws { self._context.withLockedValue { $0.application.queues.asyncTest.queue.append(id) } }
 }

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -143,7 +143,7 @@ final class QueueTests: XCTestCase {
         XCTAssertEqual(self.app.queues.test.queue.count, 0)
         XCTAssertEqual(self.app.queues.test.jobs.count, 0)
 
-        await XCTAssertEqualAsync(try await promise1.futureResult.get(), "quux")
+        await XCTAssertEqualAsync(try await promise1.futureResult.get(), "bar")
         await XCTAssertEqualAsync(try await promise2.futureResult.get(), "baz")
     }
 
@@ -245,6 +245,26 @@ final class QueueTests: XCTestCase {
             promise.succeed()
         }
         try await promise.futureResult.get()
+    }
+
+    func testPerQueueWorkerCount() async throws {
+        let count = self.app.eventLoopGroup.any().makePromise(of: Int.self)
+        self.app.queues.use(custom: WorkerCountDriver(count: count))
+
+        let serialQueue = QueueName(string: "serial", workerCount: 1)
+        try self.app.queues.startInProcessJobs(on: serialQueue)
+        await XCTAssertEqualAsync(try await count.futureResult.get(), 1)
+    }
+
+    func testPerQueueWorkerCountClampedToGlobal() async throws {
+        let count = self.app.eventLoopGroup.any().makePromise(of: Int.self)
+        self.app.queues.use(custom: WorkerCountDriver(count: count))
+        self.app.queues.configuration.workerCount = 2
+
+        // Per-queue value exceeds the global limit; should be clamped to 2.
+        let queue = QueueName(string: "clamped", workerCount: 99)
+        try self.app.queues.startInProcessJobs(on: queue)
+        await XCTAssertEqualAsync(try await count.futureResult.get(), 2)
     }
 
     func testCustomWorkerCount() async throws {
@@ -512,6 +532,27 @@ final class QueueTests: XCTestCase {
         XCTAssertEqual(self.app.queues.test.jobs.count, 0)
     }
 
+    func testWorkerCount1ExecutesJobsSequentially() async throws {
+        let events = NIOLockedValueBox<[String]>([])
+        let allDone = self.app.eventLoopGroup.any().makePromise(of: Void.self)
+        let completedCount = ManagedAtomic<Int>(0)
+
+        self.app.queues.configuration.workerCount = 1
+        self.app.queues.add(SlowJob(events: events, completedCount: completedCount, allDone: allDone))
+
+        // Dispatch both jobs before starting the worker so they're already in the queue.
+        try await self.app.queues.queue.dispatch(SlowJob.self, .init(name: "A")).get()
+        try await self.app.queues.queue.dispatch(SlowJob.self, .init(name: "B")).get()
+
+        try self.app.queues.startInProcessJobs()
+
+        try await allDone.futureResult.get()
+
+        // With workerCount = 1 there is a single `while await runOneJob()` loop.
+        // Job A completes entirely before job B is even popped, proving sequential execution.
+        XCTAssertEqual(events.withLockedValue { $0 }, ["A started", "A finished", "B started", "B finished"])
+    }
+
     func testStuffThatIsntActuallyUsedAnywhere() {
         XCTAssertEqual(self.app.queues.queue(.default).key, "vapor_queues[default]")
         XCTAssertNotNil(QueuesEventLoopPreference.indifferent.delegate(for: self.app.eventLoopGroup))
@@ -641,6 +682,23 @@ struct TestingScheduledJob: ScheduledJob {
 struct AsyncTestingScheduledJob: AsyncScheduledJob {
     var count = ManagedAtomic<Int>(0)
     func run(context _: QueueContext) async throws { self.count.wrappingIncrement(ordering: .relaxed) }
+}
+
+struct SlowJob: AsyncJob {
+    struct Payload: Codable { let name: String }
+
+    let events: NIOLockedValueBox<[String]>
+    let completedCount: ManagedAtomic<Int>
+    let allDone: EventLoopPromise<Void>
+
+    func dequeue(_ context: QueueContext, _ payload: Payload) async throws {
+        self.events.withLockedValue { $0.append("\(payload.name) started") }
+        try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        self.events.withLockedValue { $0.append("\(payload.name) finished") }
+        if self.completedCount.wrappingIncrementThenLoad(ordering: .relaxed) == 2 {
+            self.allDone.succeed(())
+        }
+    }
 }
 
 struct Foo1: Job {


### PR DESCRIPTION
Adds the ability to specify the number of workers assigned to an individual queue from one to the default system-wide maximum.

Setting the queue's workerCount parameter to one ensures that jobs execute one at a time. A further change was to implement popFirst to replace popLast to give the more intuitive FIFO behaviour instead of LIFO.

An extended test ensures that two jobs submitted to the queue before it is started will execute in the order of submission and first completes before the second commences.
